### PR TITLE
Update monolith-service image tag to 3ea468f426d771d85860185fd8540f4f255cbd60

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:85a1034038a0f0fc249f6a9d737b88ad1d6b55c2
+          image: deepinchat/monolith-service:3ea468f426d771d85860185fd8540f4f255cbd60
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: 85a1034038a0f0fc249f6a9d737b88ad1d6b55c2
+    newTag: 3ea468f426d771d85860185fd8540f4f255cbd60


### PR DESCRIPTION
This PR updates the monolith-service image tag to 3ea468f426d771d85860185fd8540f4f255cbd60.