### PR TITLE
Update monolith-service image tag to 91e2caae3098adc43672c98a46787c2cf99b0b74

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:3ea468f426d771d85860185fd8540f4f255cbd60
+          image: deepinchat/monolith-service:91e2caae3098adc43672c98a46787c2cf99b0b74
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: 3ea468f426d771d85860185fd8540f4f255cbd60
+    newTag: 91e2caae3098adc43672c98a46787c2cf99b0b74


### PR DESCRIPTION
This PR updates the monolith-service image tag to 91e2caae3098adc43672c98a46787c2cf99b0b74.