### PR TITLE
Update monolith-service image tag to 86cb5119578feb7ea6d7305f7b08be595def6100

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:91e2caae3098adc43672c98a46787c2cf99b0b74
+          image: deepinchat/monolith-service:86cb5119578feb7ea6d7305f7b08be595def6100
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: 91e2caae3098adc43672c98a46787c2cf99b0b74
+    newTag: 86cb5119578feb7ea6d7305f7b08be595def6100


### PR DESCRIPTION
This PR updates the monolith-service image tag to 86cb5119578feb7ea6d7305f7b08be595def6100.