### PR TITLE
Update monolith-service image tag to 1e3341d7aaf10a6916487b6bcdaed164df7e114e

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:91e2caae3098adc43672c98a46787c2cf99b0b74
+          image: deepinchat/monolith-service:1e3341d7aaf10a6916487b6bcdaed164df7e114e
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: 91e2caae3098adc43672c98a46787c2cf99b0b74
+    newTag: 1e3341d7aaf10a6916487b6bcdaed164df7e114e


### PR DESCRIPTION
This PR updates the monolith-service image tag to 1e3341d7aaf10a6916487b6bcdaed164df7e114e.