### PR TITLE
Update monolith-service image tag to bcd8de4bc3b0308e733754bf6c56c79225c11d3f

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:fc2f62df77119dc4029a534819ac1a161229d6bc
+          image: deepinchat/monolith-service:bcd8de4bc3b0308e733754bf6c56c79225c11d3f
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: fc2f62df77119dc4029a534819ac1a161229d6bc
+    newTag: bcd8de4bc3b0308e733754bf6c56c79225c11d3f


### PR DESCRIPTION
This PR updates the monolith-service image tag to bcd8de4bc3b0308e733754bf6c56c79225c11d3f.