### PR TITLE
Update monolith-service image tag to 9b21f0eee2b4759957a1eaa93b83c3484f60158f

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:bcd8de4bc3b0308e733754bf6c56c79225c11d3f
+          image: deepinchat/monolith-service:9b21f0eee2b4759957a1eaa93b83c3484f60158f
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: bcd8de4bc3b0308e733754bf6c56c79225c11d3f
+    newTag: 9b21f0eee2b4759957a1eaa93b83c3484f60158f


### PR DESCRIPTION
This PR updates the monolith-service image tag to 9b21f0eee2b4759957a1eaa93b83c3484f60158f.