### PR TITLE
Update monolith-service image tag to 5900ac02321ccc5ded9df44e2e69105cef125e59

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:bcd8de4bc3b0308e733754bf6c56c79225c11d3f
+          image: deepinchat/monolith-service:5900ac02321ccc5ded9df44e2e69105cef125e59
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: bcd8de4bc3b0308e733754bf6c56c79225c11d3f
+    newTag: 5900ac02321ccc5ded9df44e2e69105cef125e59


### PR DESCRIPTION
This PR updates the monolith-service image tag to 5900ac02321ccc5ded9df44e2e69105cef125e59.