### PR TITLE
Update monolith-service image tag to 01a0b6f330af7950479742f90aabfa8a8013b01e

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:489bb829c182c03585f9734e5e0c149182480b75
+          image: deepinchat/monolith-service:01a0b6f330af7950479742f90aabfa8a8013b01e
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: 489bb829c182c03585f9734e5e0c149182480b75
+    newTag: 01a0b6f330af7950479742f90aabfa8a8013b01e


### PR DESCRIPTION
This PR updates the monolith-service image tag to 01a0b6f330af7950479742f90aabfa8a8013b01e.