### PR TITLE
Update monolith-service image tag to dfa81946d59b7a56df3a67ba77d896c1d27250b5

### DIFF
--- a/argocd/monolith-service/base/deployment.yaml
+++ b/argocd/monolith-service/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: monolith-service
-          image: deepinchat/monolith-service:489bb829c182c03585f9734e5e0c149182480b75
+          image: deepinchat/monolith-service:dfa81946d59b7a56df3a67ba77d896c1d27250b5
           ports:
             - containerPort: 8080
           resources:

--- a/argocd/monolith-service/nas/kustomization.yaml
+++ b/argocd/monolith-service/nas/kustomization.yaml
@@ -6,4 +6,4 @@ patchesStrategicMerge:
   - deployment.yaml
 images:
   - name: deepinchat/monolith-service
-    newTag: 489bb829c182c03585f9734e5e0c149182480b75
+    newTag: dfa81946d59b7a56df3a67ba77d896c1d27250b5


### PR DESCRIPTION
This PR updates the monolith-service image tag to dfa81946d59b7a56df3a67ba77d896c1d27250b5.